### PR TITLE
JMK_53: added @CreationTimestamp and @UpdateTimestamp in Freelancer 

### DIFF
--- a/src/main/java/com/common/entity/Freelancer.java
+++ b/src/main/java/com/common/entity/Freelancer.java
@@ -7,6 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
@@ -69,9 +72,11 @@ public class Freelancer {
     @Column(name = "profile_status")
     private ProfileStatus profileStatus;
 
+    @CreationTimestamp
     @Column(name = "created_at")
     private Timestamp createdAt;
 
+    @UpdateTimestamp
     @Column(name = "updated_at")
     private Timestamp updatedAt;
 }


### PR DESCRIPTION
The issue that timestamps were having null value even after successful profile creation was due missing annotations on the freelancer entity @CreationTimestamp and @UpdateTimestamp. Added those and testing from frontend is done, both created_at and updated_at are working fine as expected