### PR TITLE
JMK_58: adding build element to include lombok for compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,4 +48,22 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Since, we are not using Lombok foro DTOs and Entities, the common need to build with lombok annotation processor.