### PR TITLE
JMK_56: added global CORS config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/common/config/CorsConfig.java
+++ b/src/main/java/com/common/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:5173","http://localhost:5174","http://localhost:5175")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/src/main/java/com/common/config/CorsConfig.java
+++ b/src/main/java/com/common/config/CorsConfig.java
@@ -20,7 +20,7 @@ public class CorsConfig {
                 if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
                     registry.addMapping("/**")
                             .allowedOrigins(allowedOrigins.split(","))
-                            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                            .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                             .allowedHeaders("*")
                             .allowCredentials(true);
                 }

--- a/src/main/java/com/common/config/CorsConfig.java
+++ b/src/main/java/com/common/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -8,16 +9,21 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig {
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:5173","http://localhost:5174","http://localhost:5175")
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
+                if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
+                    registry.addMapping("/**")
+                            .allowedOrigins(allowedOrigins.split(","))
+                            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                            .allowedHeaders("*")
+                            .allowCredentials(true);
+                }
             }
         };
     }


### PR DESCRIPTION
Added global CORS configuration in the  to allow cross-origin requests from the frontend.
Allowed Origins
http://localhost:5173
http://localhost:5174
http://localhost:5175
These local frontend ports are now permitted to make requests to backend services, with support for all standard HTTP methods.