### PR TITLE
JMK_61: Added ClientNotFoundException from jm-job-posting

### DIFF
--- a/src/main/java/com/common/entity/Client.java
+++ b/src/main/java/com/common/entity/Client.java
@@ -1,0 +1,70 @@
+package com.jobmatrix.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "clients")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class Client {
+
+    @Id
+    @Column(name = "client_id", nullable = false, updatable = false)
+    private UUID clientId;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "bio")
+    private String bio;
+
+    @Column(name = "profile_photo_url")
+    private String profilePhotoURL;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "company_size")
+    private String companySize;
+
+    @Column(name = "industry")
+    private String industry;
+
+    @Column(name = "timezone")
+    private String timeZone;
+
+    @Column(name = "city")
+    private String city;
+
+    @Column(name = "state")
+    private String state;
+
+    @Column(name = "country")
+    private String country;
+
+    @Column(name = "postal_code")
+    private String postalCode;
+
+    @Column(name = "address")
+    private String address;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/common/exceptionHandeling/ClientNotFoundException.java
+++ b/src/main/java/com/common/exceptionHandeling/ClientNotFoundException.java
@@ -1,0 +1,9 @@
+package com.common.exceptionHandeling;
+
+import java.util.UUID;
+
+public class ClientNotFoundException extends RuntimeException {
+    public ClientNotFoundException(UUID clientId) {
+        super("Client not found with ID: " + clientId);
+    }
+}


### PR DESCRIPTION
- Added ClientNotFoundException to be used in both jm-job-posting and jm-profile-management.
- It works by giving an exception message "Client not found from Client Id - \<ClientId>" when the clientId (UUID) is not found in the database.