### PR TITLE
JMK_61: Add ClientNotFoundException for jm-job-posting and jm-profile-management

### DIFF
--- a/src/main/java/com/common/entity/Client.java
+++ b/src/main/java/com/common/entity/Client.java
@@ -1,4 +1,4 @@
-package com.jobmatrix.entity;
+package com.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/common/exceptionHandling/ClientNotFoundException.java
+++ b/src/main/java/com/common/exceptionHandling/ClientNotFoundException.java
@@ -1,0 +1,9 @@
+package com.common.exceptionHandling;
+
+import java.util.UUID;
+
+public class ClientNotFoundException extends RuntimeException {
+    public ClientNotFoundException(UUID clientId) {
+        super("Client not found with ID: " + clientId);
+    }
+}


### PR DESCRIPTION
- Added ClientNotFoundException to be used in both jm-job-posting and jm-profile-management.
- It works by giving an exception message "Client not found from Client Id - <ClientId>" when the clientId (UUID) is not found in the database.
- Change path of Client Entity in import statements from ```com.jobmatrix.Entity.Client``` to ```com.common.Entity.Client```