### PR TITLE
JMK_77: Add method to convert string to list and also verifying the e…

### DIFF
--- a/src/main/java/com/common/exceptionHandling/InvalidEnumValueException.java
+++ b/src/main/java/com/common/exceptionHandling/InvalidEnumValueException.java
@@ -1,0 +1,7 @@
+package com.common.exceptionHandling;
+
+public class InvalidEnumValueException extends RuntimeException {
+    public InvalidEnumValueException(String enumName, String invalidValue) {
+        super("Invalid value '" + invalidValue + "' for enum: " + enumName);
+    }
+}

--- a/src/main/java/com/common/util/EnumUtils.java
+++ b/src/main/java/com/common/util/EnumUtils.java
@@ -1,4 +1,4 @@
-package com.common.utility;
+package com.common.util;
 
 import com.common.exceptionHandling.InvalidEnumValueException;
 import java.util.Arrays;
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class StringToList {
-    public static <E extends Enum<E>> List<E> convertToEnumList(String input, Class<E> enumClass) {
+public class EnumUtils {
+    public static <E extends Enum<E>> List<E> parseEnumList(String input, Class<E> enumClass) {
         if (input == null || input.trim().isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/com/common/utility/StringToList.java
+++ b/src/main/java/com/common/utility/StringToList.java
@@ -1,0 +1,26 @@
+package com.common.utility;
+
+import com.common.exceptionHandling.InvalidEnumValueException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StringToList {
+    public static <E extends Enum<E>> List<E> convertToEnumList(String input, Class<E> enumClass) {
+        if (input == null || input.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(input.split(","))
+                .map(String::trim)
+                .map(value -> {
+                    try {
+                        return Enum.valueOf(enumClass, value.toUpperCase());
+                    } catch (IllegalArgumentException e) {
+                        throw new InvalidEnumValueException(enumClass.getSimpleName(), value);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Adding a utility method called convertToEnumList in the common module to help convert comma-separated strings into a list of enum values safely. If any value in the input string doesn’t match the expected enum, it throws a custom InvalidEnumValueException