### PR TITLE
JMK_129: Used Jackson annotation to prevent recursion in job posting endpoints

### DIFF
--- a/src/main/java/com/common/entity/JobPosting.java
+++ b/src/main/java/com/common/entity/JobPosting.java
@@ -1,5 +1,6 @@
 package com.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.common.enums.BudgetType;
 import com.common.enums.ExperienceLevel;
 import com.common.enums.JobPostingStatus;
@@ -78,9 +79,11 @@ public class JobPosting {
             joinColumns = @JoinColumn(name = "job_posting_id"),
             inverseJoinColumns = @JoinColumn(name = "skill_id")
     )
+    @JsonManagedReference
     private Set<Skill> skills;
 
     @OneToMany(mappedBy = "jobPosting", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<JobPostingQuestion> questions;
 
     @CreationTimestamp

--- a/src/main/java/com/common/entity/JobPostingQuestion.java
+++ b/src/main/java/com/common/entity/JobPostingQuestion.java
@@ -1,5 +1,6 @@
 package com.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -33,5 +34,6 @@ public class JobPostingQuestion{
 
     @ManyToOne
     @JoinColumn(name = "job_posting_id", nullable = false)
+    @JsonBackReference
     private JobPosting jobPosting;
 }

--- a/src/main/java/com/common/entity/Skill.java
+++ b/src/main/java/com/common/entity/Skill.java
@@ -1,5 +1,6 @@
 package com.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -33,5 +34,6 @@ public class Skill {
     private LocalDateTime updatedAt;
 
     @ManyToMany(mappedBy = "skills", fetch = FetchType.LAZY)
+    @JsonBackReference
     private Set<JobPosting> jobPostings = new HashSet<>();
 }


### PR DESCRIPTION
# [Jira@JMK_129](https://punjabskillsbank.atlassian.net/browse/JMK-129?atlOrigin=eyJpIjoiNjJiNDYwZWQ3NDJjNDU2N2E0ODRiYmJmOTZmNTA5YmUiLCJwIjoiaiJ9)

Under ManyToMany and OneToMany annotated entities, `@JsonManagedReference` and `@JsonBackReference` are used to prevent recursion in job posting endpoints.